### PR TITLE
Add ingress, update service

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -270,6 +270,16 @@ Sets extra service account annotations
 {{- end -}}
 
 {{/*
+Sets extra ingress annotations
+*/}}
+{{- define "vault.ingress.annotations" -}}
+  {{- if and (ne .mode "dev") .Values.server.ingress.annotations }}
+  annotations:
+    {{- toYaml .Values.server.ingress.annotations | nindent 4 }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Set's the container resources if the user has set any.
 */}}
 {{- define "vault.resources" -}}

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -1,0 +1,13 @@
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ template "vault.fullname" . }}
+  {{ template "vault.ingress.annotations" . }}
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "vault.fullname" . }}
+              servicePort: {{ .Values.server.service.port }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -16,6 +16,9 @@ metadata:
     # https://github.com/kubernetes/kubernetes/issues/58662
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
+  {{- if .Values.server.service.type }}
+  type: {{ .Values.server.service.type }}
+  {{- end }}
   {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -98,6 +98,10 @@ server:
     # Target port to which the service should be mapped to
     targetPort: 8200
 
+  # Configuration for an ingress to the Vault service
+  ingress:
+    annotations: {}
+
   # This configures the Vault Statefulset to create a PVC for data
   # storage when using the file backend.
   # See https://www.vaultproject.io/docs/audit/index.html to know more


### PR DESCRIPTION
Adds a basic ingress, our ingress controller will create the aws lb. 
Adds the ability to set the service type so we can set it to NodePort.

These two changes will allow vault to become available at vault.int.[env].takescoop.com

