### PR TITLE
Add service type

### DIFF
--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -19,6 +19,9 @@ metadata:
 {{ toYaml .Values.server.service.annotations | indent 4 }}
 {{- end }}
 spec:
+  {{- if .Values.server.service.type }}
+  type: {{ .Values.server.service.type }}
+  {{- end }}
   {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}
   {{- end }}


### PR DESCRIPTION
Allows setting the service type for the service that sits in front of the stateful set. 

Also added a PR for upstream so we can remove eventually 
https://github.com/hashicorp/vault-helm/pull/65