### PR TITLE
Add publish step to circleCI flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,6 @@ workflows:
           requires:
             - bats-unit-test
           context: publish
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,36 @@ jobs:
       - checkout
       - run: make test-image
       - run: make test-unit
+  publish:
+    docker:
+      - image: $DOCKER_REGISTRY_URL/circleci-kubernetes:3
+        auth:
+          username: $DOCKER_REGISTRY_USERNAME
+          password: $DOCKER_REGISTRY_PASSWORD
+    steps:
+      - checkout
+      - run: 
+          name: Install and initialize helm
+          command: |
+            curl https://storage.googleapis.com/kubernetes-helm/helm-v2.14.0-linux-386.tar.gz | tar xvz
+            curl -fL https://getcli.jfrog.io | sh
+            ./linux-386/helm init --client-only
+      - run: 
+          name: Upload helm-vault to helm repo
+          command: |
+            ./linux-386/helm package .
+            ./jfrog rt upload *.tgz / --url https://takescoop.jfrog.io/takescoop/helm-local --user $DOCKER_REGISTRY_USERNAME --apikey $DOCKER_REGISTRY_PASSWORD
+          environment:
+            JFROG_CLI_OFFER_CONFIG: false
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - bats-unit-test 
+      - bats-unit-test
+      - publish:
+          requires:
+            - bats-unit-test
+          context: publish
+          # filters:
+          #   branches:
+          #     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
         auth:
           username: $DOCKER_REGISTRY_USERNAME
           password: $DOCKER_REGISTRY_PASSWORD
+    working_directory: /vault
     steps:
       - checkout
       - run: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             curl -fL https://getcli.jfrog.io | sh
             ./linux-386/helm init --client-only
       - run: 
-          name: Upload helm-vault to helm repo
+          name: Upload vault-helm to helm repo
           command: |
             ./linux-386/helm package .
             ./jfrog rt upload *.tgz / --url https://takescoop.jfrog.io/takescoop/helm-local --user $DOCKER_REGISTRY_USERNAME --apikey $DOCKER_REGISTRY_PASSWORD

--- a/.helmignore
+++ b/.helmignore
@@ -7,6 +7,9 @@ test/
 
 .DS_Store
 .circleci/
+Makefile
+.gitignore
+.helmignore
 
 # Common backup files
 *.swp

--- a/.helmignore
+++ b/.helmignore
@@ -2,3 +2,21 @@
 .terraform/
 bin/
 test/
+
+### Scoop additions ###
+
+.DS_Store
+.circleci/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+*.md
+
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -7,3 +7,4 @@ icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b8458
 sources:
   - https://github.com/hashicorp/vault
   - https://github.com/hashicorp/vault-helm
+  - https://github.com/takescoop/vault-helm

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vault Helm Chart
+# Vault Helm Chart [![CircleCI](https://circleci.com/gh/TakeScoop/vault-helm/tree/master.svg?style=svg)](https://circleci.com/gh/TakeScoop/vault-helm/tree/master)
 
 This repository contains the official HashiCorp Helm chart for installing
 and configuring Vault on Kubernetes. This chart supports multiple use

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Vault Helm Chart [![CircleCI](https://circleci.com/gh/TakeScoop/vault-helm/tree/master.svg?style=svg)](https://circleci.com/gh/TakeScoop/vault-helm/tree/master)
 
+**Maintainer:** [@ryanwholey](github.com/ryanwholey)
+
 This repository contains the official HashiCorp Helm chart for installing
 and configuring Vault on Kubernetes. This chart supports multiple use
 cases of Vault on Kubernetes depending on the values provided.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ For full documentation on this Helm chart along with all the ways you can
 use Vault with Kubernetes, please see the
 [Vault and Kubernetes documentation](https://www.vaultproject.io/docs/platform/k8s/index.html).
 
+## Why the fork?
+
+The vault-helm repository is fairly new. When started integrating it into our clusters, there were three distinct pieces that were missing:
+- Ingress definition ([merged](https://github.com/hashicorp/vault-helm/commit/9dd6bad74123673a16e35f167f1e1088f9b5050d))
+    - While tunnelbox still lives in convox, it can't use k8s dns. Instead we'll have to use an ingress until we migrate tunnelbox.
+- Service type configuration (NodePort) ([pr submitted](https://github.com/hashicorp/vault-helm/pull/65))
+    - Our ingress controllers depend on services being of type NodePort and is currently not configurable
+- Published to a repository
+    - While we could download a tagged release as [noted in the docs](https://github.com/hashicorp/vault-helm/tree/d696408fae1524979c82e9b9ae98a63d4f00fad7#usage), this is a bit too messy for us to include in our cluster base installation.
+
+When these three things are completed, we can celebrate and move off of the fork, onto the upstream chart.
+
 ## Prerequisites
 
 To use the charts here, [Helm](https://helm.sh/) must be installed in your

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ use Vault with Kubernetes, please see the
 ## Why the fork?
 
 The vault-helm repository is fairly new. When started integrating it into our clusters, there were three distinct pieces that were missing:
-- Ingress definition ([merged](https://github.com/hashicorp/vault-helm/commit/9dd6bad74123673a16e35f167f1e1088f9b5050d))
-    - While tunnelbox still lives in convox, it can't use k8s dns. Instead we'll have to use an ingress until we migrate tunnelbox.
 - Service type configuration (NodePort) ([pr submitted](https://github.com/hashicorp/vault-helm/pull/65))
     - Our ingress controllers depend on services being of type NodePort and is currently not configurable
 - Published to a repository


### PR DESCRIPTION
Hashicorp helm chart is[ not being published to a repository ](https://github.com/hashicorp/vault-helm#usage)at the moment. The recommend cloning the git repo and installing like that. We need a saner approach in our base installer.
