### PR TITLE
Update PodDisruptionBudget label selector to match StatefulSet

### DIFF
--- a/templates/server-disruptionbudget.yaml
+++ b/templates/server-disruptionbudget.yaml
@@ -16,7 +16,7 @@ spec:
   maxUnavailable: {{ template "vault.pdb.maxUnavailable" . }}
   selector:
     matchLabels:
-      app: {{ template "vault.name" . }}
-      release: "{{ .Release.Name }}"
+      app.kubernetes.io/name: {{ template "vault.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       component: server
 {{- end -}}


### PR DESCRIPTION
The label selector value for a PDB must be a subset of the pods' labels in order to match:

https://github.com/TakeScoop/vault-helm/blob/master/templates/server-statefulset.yaml#L28-L32