### PR TITLE
Remove chart name/version label from statefulset selector

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -19,7 +19,6 @@ spec:
     type: OnDelete
   selector:
     matchLabels:
-      helm.sh/chart: {{ template "vault.chart" . }}
       app.kubernetes.io/name: {{ template "vault.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       component: server


### PR DESCRIPTION
The `spec` of a StatefulSet is mostly immutable, other than the template and replicas (among a few other minor properties). `helm.sh/chart` has values like `vault-0.1.5`. Any version upgrade of this chart will cause a mutation, which k8s will reject.

This label does belong on the pod, since pods are immutable. The StatefulSet only needs to match on `app.kubernetes.io/*` and `component` labels, which will never change. 